### PR TITLE
Clarify Agrona-derived file attribution

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,9 @@
 Agent.jl
 Copyright 2024-2026 Rubus Technologies Inc.
 
-This product implements the Agent protocol and idle strategies inspired by
-Agrona, Copyright 2014-2025 Real Logic Limited, which is distributed under the
-Apache License, Version 2.0.
+This product includes software adapted from Agrona
+(https://github.com/aeron-io/agrona):
+
+    Copyright 2014-2025 Real Logic Limited.
+
+Agrona is licensed under the Apache License, Version 2.0.

--- a/benchmark/environment.jl
+++ b/benchmark/environment.jl
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 Rubus Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 using Pkg
 
 function git_value(command::Cmd)

--- a/benchmark/runbenchmarks.jl
+++ b/benchmark/runbenchmarks.jl
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 Rubus Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 using Agent
 using BenchmarkTools
 

--- a/benchmark/runnerbenchmarks.jl
+++ b/benchmark/runnerbenchmarks.jl
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 Rubus Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 using Statistics
 using ThreadPinning
 

--- a/benchmark/setup.jl
+++ b/benchmark/setup.jl
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 Rubus Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 using Pkg
 
 Pkg.activate(@__DIR__)

--- a/ext/AgentThreadPinningExt.jl
+++ b/ext/AgentThreadPinningExt.jl
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 Rubus Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 module AgentThreadPinningExt
 
 using Agent

--- a/src/Agent.jl
+++ b/src/Agent.jl
@@ -1,3 +1,9 @@
+# Copyright 2014-2025 Real Logic Limited.
+# Copyright 2024-2026 Rubus Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ported from Agrona and substantially modified for Julia.
+
 """
     Agent
 

--- a/src/abstractagent.jl
+++ b/src/abstractagent.jl
@@ -1,3 +1,9 @@
+# Copyright 2014-2025 Real Logic Limited.
+# Copyright 2024-2026 Rubus Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ported from Agrona and substantially modified for Julia.
+
 """
     AgentTerminationException([message]; expected=true)
 

--- a/src/agentinvoker.jl
+++ b/src/agentinvoker.jl
@@ -1,3 +1,9 @@
+# Copyright 2014-2025 Real Logic Limited.
+# Copyright 2024-2026 Rubus Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ported from Agrona and substantially modified for Julia.
+
 """
     AgentInvoker(agent; error_handler=nothing, error_counter=nothing)
 

--- a/src/agentrunner.jl
+++ b/src/agentrunner.jl
@@ -1,3 +1,9 @@
+# Copyright 2014-2025 Real Logic Limited.
+# Copyright 2024-2026 Rubus Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ported from Agrona and substantially modified for Julia.
+
 const RUNNER_SAFEPOINT_INTERVAL = 1024
 @assert ispow2(RUNNER_SAFEPOINT_INTERVAL)
 

--- a/src/backoffidlestrategy.jl
+++ b/src/backoffidlestrategy.jl
@@ -1,3 +1,9 @@
+# Copyright 2014-2025 Real Logic Limited.
+# Copyright 2024-2026 Rubus Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ported from Agrona and substantially modified for Julia.
+
 @enum BackoffIdleState begin
     BACKOFF_IDLE_STATE_NOT_IDLE
     BACKOFF_IDLE_STATE_SPINNING

--- a/src/busyspinidlestrategy.jl
+++ b/src/busyspinidlestrategy.jl
@@ -1,3 +1,9 @@
+# Copyright 2014-2025 Real Logic Limited.
+# Copyright 2024-2026 Rubus Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ported from Agrona and substantially modified for Julia.
+
 """
     struct BusySpinIdleStrategy <: IdleStrategy
 

--- a/src/compositeagent.jl
+++ b/src/compositeagent.jl
@@ -1,3 +1,9 @@
+# Copyright 2014-2025 Real Logic Limited.
+# Copyright 2024-2026 Rubus Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ported from Agrona and substantially modified for Julia.
+
 """
 Group multiple agents into a composite so they can be scheduled as a unit.
 """

--- a/src/controllableidlestrategy.jl
+++ b/src/controllableidlestrategy.jl
@@ -1,3 +1,9 @@
+# Copyright 2014-2025 Real Logic Limited.
+# Copyright 2024-2026 Rubus Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ported from Agrona and substantially modified for Julia.
+
 """
     ControllableIdleMode
 

--- a/src/dynamiccompositeagent.jl
+++ b/src/dynamiccompositeagent.jl
@@ -1,3 +1,9 @@
+# Copyright 2014-2025 Real Logic Limited.
+# Copyright 2024-2026 Rubus Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ported from Agrona and substantially modified for Julia.
+
 """
     DynamicCompositeStatus
 

--- a/src/errorhandling.jl
+++ b/src/errorhandling.jl
@@ -1,3 +1,9 @@
+# Copyright 2014-2025 Real Logic Limited.
+# Copyright 2024-2026 Rubus Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ported from Agrona and substantially modified for Julia.
+
 """
 Error reporting utilities shared by agent runners and invokers.
 

--- a/src/idlestrategy.jl
+++ b/src/idlestrategy.jl
@@ -1,3 +1,9 @@
+# Copyright 2014-2025 Real Logic Limited.
+# Copyright 2024-2026 Rubus Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ported from Agrona and substantially modified for Julia.
+
 """
     Idle strategy for use by threads when they do not have work to do.
 

--- a/src/noopidlestrategy.jl
+++ b/src/noopidlestrategy.jl
@@ -1,3 +1,9 @@
+# Copyright 2014-2025 Real Logic Limited.
+# Copyright 2024-2026 Rubus Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ported from Agrona and substantially modified for Julia.
+
 """
     struct NoOpIdleStrategy <: IdleStrategy
 

--- a/src/sleepingidlestrategy.jl
+++ b/src/sleepingidlestrategy.jl
@@ -1,3 +1,9 @@
+# Copyright 2014-2025 Real Logic Limited.
+# Copyright 2024-2026 Rubus Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ported from Agrona and substantially modified for Julia.
+
 """
     struct SleepingIdleStrategy <: IdleStrategy
 

--- a/src/sleepingmillisidlestrategy.jl
+++ b/src/sleepingmillisidlestrategy.jl
@@ -1,3 +1,9 @@
+# Copyright 2014-2025 Real Logic Limited.
+# Copyright 2024-2026 Rubus Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ported from Agrona and substantially modified for Julia.
+
 """
     struct SleepingMillisIdleStrategy <: IdleStrategy
 

--- a/src/yieldingidlestrategy.jl
+++ b/src/yieldingidlestrategy.jl
@@ -1,3 +1,9 @@
+# Copyright 2014-2025 Real Logic Limited.
+# Copyright 2024-2026 Rubus Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ported from Agrona and substantially modified for Julia.
+
 """
     struct YieldingIdleStrategy <: IdleStrategy
 

--- a/test/runner_liveness_child.jl
+++ b/test/runner_liveness_child.jl
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 Rubus Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 using Agent
 
 struct LivenessAgent

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 Rubus Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 using Test
 using Agent
 using Aqua

--- a/test/test_agent_interface.jl
+++ b/test/test_agent_interface.jl
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 Rubus Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 using Test
 using Agent
 

--- a/test/test_agentinvoker.jl
+++ b/test/test_agentinvoker.jl
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 Rubus Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 using Test
 using Agent
 

--- a/test/test_agentrunner.jl
+++ b/test/test_agentrunner.jl
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 Rubus Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 using Test
 using Agent
 using StableTasks

--- a/test/test_compositeagent.jl
+++ b/test/test_compositeagent.jl
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 Rubus Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 using Test
 using Agent
 

--- a/test/test_dynamiccompositeagent.jl
+++ b/test/test_dynamiccompositeagent.jl
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 Rubus Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 using Test
 using Agent
 

--- a/test/test_idle_strategies.jl
+++ b/test/test_idle_strategies.jl
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 Rubus Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 using Test
 using Agent
 

--- a/test/test_integration.jl
+++ b/test/test_integration.jl
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 Rubus Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 using Test
 using Agent
 

--- a/test/test_runner_liveness.jl
+++ b/test/test_runner_liveness.jl
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 Rubus Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 using Test
 using Agent
 

--- a/test/test_thread_pinning.jl
+++ b/test/test_thread_pinning.jl
@@ -1,3 +1,6 @@
+# Copyright 2024-2026 Rubus Technologies Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 struct PinningDependencyProbeAgent end
 
 Agent.name(::PinningDependencyProbeAgent) = "pinning-dependency-probe"


### PR DESCRIPTION
## Summary

- retain Real Logic Limited copyright notices in Agrona-derived runtime sources
- mark those sources as ported and substantially modified for Julia
- add Rubus Technologies Inc. copyright and Apache-2.0 SPDX headers across source, extension, tests, and benchmarks
- strengthen the NOTICE wording from “inspired by” to software “adapted from” Agrona

## Motivation

Agent.jl implements and adapts Agrona's agent protocol and idle strategies. File-level provenance makes the Apache-2.0 licensing and ownership boundaries explicit: Real Logic retains attribution for Agrona-derived work, while Rubus owns the Julia modifications and original supporting code.

## User impact

No API or runtime behavior changes.

## Validation

- Julia 1.12.6 package tests passed
- 929 behavioral and QA checks passed, including Aqua and the optional ThreadPinning extension
- `git diff --check` passed
